### PR TITLE
Update local metadata only when installing the first pkg

### DIFF
--- a/zoomdata/install.sls
+++ b/zoomdata/install.sls
@@ -44,6 +44,8 @@ include:
     - name: {{ package }}
     {%- if versions.get(package) %}
     - version: {{ versions[package] }}
+    {#- Update local metadata only when installing the first pkg #}
+    - refresh: {{ loop.index == 1 }}
     {%- endif %}
     - skip_verify: {{ zoomdata.gpgkey is none or zoomdata.gpgkey == '' }}
     - require:


### PR DESCRIPTION
This significantly speeds up upgrades and installation of latest package versions.