### PR TITLE
Add more env variables recognition

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -66,7 +66,10 @@ zoomdata:
     # The Spark Proxy has gone in Zoomdata 2.6 release
     #- zoomdata-spark-proxy
     - zoomdata-xvfb
-    - zoomdata-zdmanage
+    # The ``zdmanage`` tool has independent versioning, uncomment if exact version from
+    # above is not set. Or install manually afterwards.
+    # TODO: add separate tools section
+    #- zoomdata-zdmanage
 
   # Zoomdata EDC section
   edc:

--- a/zoomdata/install.sls
+++ b/zoomdata/install.sls
@@ -7,7 +7,7 @@
 
 {%- for install in (zoomdata, zoomdata.edc) %}
   {%- for package in install.packages|default([], true) %}
-    {%- if package not in packages %}
+    {%- if package and package not in packages %}
       {%- do packages.append(package) %}
       {%- do versions.update({package: install.get('version')}) %}
     {%- endif %}
@@ -271,7 +271,7 @@ zoomdata-user-limits-conf:
 {%- endfor %}
 
 # Manage Zoomdata services: first stop those were not explicitly declared and
-# finally start all defined in defaults or Pillar
+# finally start all defined in defaults or Pillar.
 
 {%- if init_available %}
 
@@ -309,9 +309,9 @@ zoomdata-user-limits-conf:
 
 {%- else %}
 
-# Try to enable Zoomdata services in "manual" way if Salt `service` state module
-# is currently not available (e.g. during Docker or Packer build when is no init
-# system running)
+# Try to enable Zoomdata services in "manual" way if Salt `service` state
+# module is currently not available (e.g. during Docker or Packer build when
+# there is no init system running).
 
   {%- for service in packages %}
 

--- a/zoomdata/map.jinja
+++ b/zoomdata/map.jinja
@@ -9,13 +9,48 @@
     base='default',
 ) %}
 
+{# Make sure EDC dict always exists #}
+{% do zoomdata.update({
+    'edc':      zoomdata.edc|default({}, true),
+}) %}
+
+{# Install our module to gather data #}
+{% if salt['zoomdata.inspect']|default(none) is not callable %}
+    {% do salt['saltutil.sync_modules']() %}
+{% endif %}
+
+{# Try to inspect local installation #}
+{% do zoomdata.update({
+    'local': salt['zoomdata.inspect'](versions=true)['zoomdata'],
+}) %}
+{% set packages = zoomdata.local['packages']|default([], true) +
+                  zoomdata.local.edc['packages']|default([], true) %}
+
+{# Make sure we have finished bootstrapping when some packages were
+   already installed. #}
+{% do zoomdata.update({
+    'bootstrap': packages == [] or
+                 salt['grains.get']('zoomdata:bootstrap', False),
+}) %}
+
+{% if not zoomdata['bootstrap'] and not zoomdata['enforce'] %}
+    {# Bypass state enforcement: work only with locally installed and
+       running services #}
+    {% do zoomdata.edc.update({'packages': []}) %}
+    {# If something is already installed, create global packages list:
+       for both Zoomdata core services and EDC in the single place. #}
+    {% do zoomdata.update({
+        'packages': packages,
+        'services': zoomdata.local['services'],
+    }) %}
+{% endif %}
+
 {# Read envrionment variables #}
 {% do zoomdata.update({
     'base_url': salt['environ.get']('ZOOMDATA_REPOSITORY', zoomdata.base_url),
     'release':  salt['environ.get']('ZOOMDATA_RELEASE', zoomdata.release),
     'version':  salt['environ.get']('ZOOMDATA_VERSION', zoomdata.get('version')),
     'packages': salt['environ.get']('ZOOMDATA_PACKAGES', zoomdata.get('packages')),
-    'edc':      zoomdata.edc|default({}, true),
     'services': salt['environ.get']('ZOOMDATA_SERVICES', zoomdata.get('services')),
 }) %}
 
@@ -49,37 +84,6 @@
         {% endif %}
     {% endfor %}
 {% endfor %}
-
-{# Install our module to gather data #}
-{% if salt['zoomdata.inspect']|default(none) is not callable %}
-    {% do salt['saltutil.sync_modules']() %}
-{% endif %}
-
-{# Try to inspect local installation #}
-{% do zoomdata.update({
-    'local': salt['zoomdata.inspect'](versions=true)['zoomdata'],
-}) %}
-{% set packages = zoomdata.local['packages']|default([], true) +
-                  zoomdata.local.edc['packages']|default([], true) %}
-
-{# Make sure we have finished bootstrapping when some packages were
-   already installed. #}
-{% do zoomdata.update({
-    'bootstrap': packages == [] or
-                 salt['grains.get']('zoomdata:bootstrap', False),
-}) %}
-
-{% if not zoomdata['bootstrap'] and not zoomdata['enforce'] %}
-    {# Bypass state enforcement: work only with locally installed and
-       running services #}
-    {% do zoomdata.edc.update({'packages': []}) %}
-    {# If something is already installed, create global packages list:
-       for both Zoomdata core services and EDC in the single place. #}
-    {% do zoomdata.update({
-        'packages': packages,
-        'services': zoomdata.local['services'],
-    }) %}
-{% endif %}
 
 {% for params in ('backup', 'restore') %}
     {% if zoomdata[params] is not mapping %}

--- a/zoomdata/map.jinja
+++ b/zoomdata/map.jinja
@@ -14,11 +14,41 @@
     'base_url': salt['environ.get']('ZOOMDATA_REPOSITORY', zoomdata.base_url),
     'release':  salt['environ.get']('ZOOMDATA_RELEASE', zoomdata.release),
     'version':  salt['environ.get']('ZOOMDATA_VERSION', zoomdata.get('version')),
+    'packages': salt['environ.get']('ZOOMDATA_PACKAGES', zoomdata.get('packages')),
     'edc':      zoomdata.edc|default({}, true),
+    'services': salt['environ.get']('ZOOMDATA_SERVICES', zoomdata.get('services')),
 }) %}
-{% do zoomdata.edc.update(
-    {'version': salt['environ.get']('ZOOMDATA_EDC_VERSION', zoomdata.edc.get('version'))},
-) %}
+
+{% do zoomdata.edc.update({
+    'packages': salt['environ.get']('ZOOMDATA_EDC_PACKAGES', zoomdata.edc.get('packages')),
+    'version':  salt['environ.get']('ZOOMDATA_EDC_VERSION', zoomdata.edc.get('version')),
+}) %}
+
+{# Fix short names for Zoomdata sevices and connectors by appending
+   approptiate prefix to each package and service defined via environment
+   variable. #}
+{% for group, prefix in ((none, 'zoomdata'), ('edc', 'zoomdata-edc')) %}
+    {% for item in ('packages', 'services') %}
+        {% set map = zoomdata.get(group, zoomdata) %}
+        {% if map.get(item) is string %}
+            {% set items = map[item].split(',') %}
+            {% set srvs = [] %}
+            {% for srv in items %}
+                {% if srv and not srv.startswith(prefix) %}
+                    {% do srvs.append(prefix ~ '-' ~ srv) %}
+                {% elif srv %}
+                    {% do srvs.append(srv) %}
+                {% endif %}
+            {% endfor %}
+            {% set param = {item: srvs} %}
+            {% if group %}
+                {% do zoomdata[group].update(param) %}
+            {% else %}
+                {% do zoomdata.update(param) %}
+            {% endif %}
+        {% endif %}
+    {% endfor %}
+{% endfor %}
 
 {# Install our module to gather data #}
 {% if salt['zoomdata.inspect']|default(none) is not callable %}


### PR DESCRIPTION
Honour new environment variables:
* `ZOOMDATA_PACKAGES`: comma separated list of ZD packages to install.
  `zoomdata-` prefix could be omitted for any package name.
* `ZOOMDATA_EDC_PACKAGES`: same as above, but for connectors.
  `zoomdata-edc-` prefix could be omitted.
* `ZOOMDATA_SERVICES`: comma separated list of all services to start and
  enable. `zoomdata-` prefix could be omitted.