### PR TITLE
Validate packages and services list values

### DIFF
--- a/zoomdata/map.jinja
+++ b/zoomdata/map.jinja
@@ -74,25 +74,29 @@
 {# Fix short names for Zoomdata sevices and connectors by appending
    approptiate prefix to each package and service defined via environment
    variable. #}
-{% for group, prefix in ((none, 'zoomdata'), ('edc', 'zoomdata-edc')) %}
+{% for group, prefix in ((none, 'zoomdata'), ('edc', 'zoomdata-edc'), ('tools', 'zoomdata')) %}
     {% for item in ('packages', 'services') %}
         {% set map = zoomdata.get(group, zoomdata) %}
-        {% if map.get(item) is string %}
-            {% set items = map[item].split(',') %}
-            {% set srvs = [] %}
-            {% for srv in items %}
-                {% if srv and not srv.startswith(prefix) %}
-                    {% do srvs.append(prefix ~ '-' ~ srv) %}
-                {% elif srv %}
-                    {% do srvs.append(srv) %}
-                {% endif %}
-            {% endfor %}
-            {% set param = {item: srvs} %}
-            {% if group %}
-                {% do zoomdata[group].update(param) %}
-            {% else %}
-                {% do zoomdata.update(param) %}
+        {% set value = map.get(item) %}
+        {% set items = value %}
+        {% if value is string %}
+            {% set items = value.split(',') %}
+        {% elif not value or value is not sequence %}
+            {% set items = [] %}
+        {% endif %}
+        {% set srvs = [] %}
+        {% for srv in items %}
+            {% if srv and not srv.startswith(prefix) %}
+                {% do srvs.append(prefix ~ '-' ~ srv) %}
+            {% elif srv %}
+                {% do srvs.append(srv) %}
             {% endif %}
+        {% endfor %}
+        {% set param = {item: srvs} %}
+        {% if group %}
+            {% do zoomdata[group].update(param) %}
+        {% else %}
+            {% do zoomdata.update(param) %}
         {% endif %}
     {% endfor %}
 {% endfor %}

--- a/zoomdata/remove.sls
+++ b/zoomdata/remove.sls
@@ -20,7 +20,7 @@
   {%- set uninstall = [] %}
 
   {%- for pkg in installed %}
-    {% if pkg not in packages %}
+    {%- if pkg not in packages %}
       {%- do uninstall.append(pkg) %}
     {%- elif pkg in services %}
       {%- do services.remove(pkg) %}    
@@ -43,4 +43,4 @@
 
 zoomdata-remove:
   pkg.removed:
-    - pkgs: {{ uninstall }}
+    - pkgs: {{ uninstall|yaml() }}

--- a/zoomdata/tools.sls
+++ b/zoomdata/tools.sls
@@ -5,7 +5,7 @@
 include:
   - zoomdata.repo
 
-  {%- if zoomdata.tools.packages|default([]) %}
+  {%- if zoomdata.tools['packages'] %}
 
 zoomdata-tools:
   pkg.installed:


### PR DESCRIPTION
Make sure that `packages` and `services` values in nested dictionaries have type of list or string (comma separated values). Forcibly set empty list otherwise. This reduces amount of safety checks in SLS files.
Plus small Jinja fixes.