### PR TITLE
Fix compatibility with Salt 2016.11.X

### DIFF
--- a/zoomdata/install.sls
+++ b/zoomdata/install.sls
@@ -42,9 +42,11 @@ include:
 {{ package }}_package:
   pkg.installed:
     - name: {{ package }}
-    - version: {{ versions.get(package) }}
+    {%- if versions.get(package) %}
+    - version: {{ versions[package] }}
     {#- Update local metadata only when installing the first pkg #}
     - refresh: {{ loop.index == 1 }}
+    {%- endif %}
     - skip_verify: {{ zoomdata.gpgkey|default(none, true) is none }}
     - require:
       - sls: zoomdata.repo


### PR DESCRIPTION
Do not set `version` parameter for `pkg` states if no version explicitly set via the Pillar.