### PR TITLE
Fix invoking backup state if no backup configured

### DIFF
--- a/_modules/zoomdata.py
+++ b/_modules/zoomdata.py
@@ -371,6 +371,7 @@ def inspect(limits=False,
             gpgkey = params['gpgkey'].strip()
 
         repo_root = url.path.split('/')[1]
+        # FIXME: handle ``latest`` catalog in the repo URL
         try:
             release = float(repo_root) if not release or float(repo_root) > release else release
         except ValueError:

--- a/zoomdata/backup/init.sls
+++ b/zoomdata/backup/init.sls
@@ -1,3 +1,8 @@
+{%- from 'zoomdata/map.jinja' import zoomdata %}
+
+{%- if zoomdata.backup['destination'] and (
+       zoomdata.backup['state'] or zoomdata.backup['services']) %}
+
 include:
   - zoomdata.backup.layout
   - zoomdata.backup.state
@@ -5,3 +10,15 @@ include:
   - zoomdata.backup.metadata
   - zoomdata.backup.retension
   - zoomdata.services.start
+
+{%- else %}
+
+zoomdata-backup:
+  test.show_notification:
+    - name: The backup has been disabled
+    - text: |
+        To make a backup of Zoomdata installation state or metadata you must
+        set ``zoomdata:backup:state`` or ``zoomdata:backup:services`` Pillar
+        values respectively.
+
+{%- endif %}

--- a/zoomdata/backup/layout.sls
+++ b/zoomdata/backup/layout.sls
@@ -1,6 +1,8 @@
-{%- from 'zoomdata/map.jinja' import postgres, zoomdata %}
+{%- from 'zoomdata/map.jinja' import zoomdata %}
 
-{%- if zoomdata.backup['destination'] %}
+{%- if zoomdata.backup['destination'] and (
+       zoomdata.backup['state'] or zoomdata.backup['services']) %}
+
   {%- set timestamp = salt['status.time'](zoomdata.backup['strptime']) %}
   {%- do salt['grains.set']('zoomdata:backup:latest', timestamp) %}
   {%- set backup_dir = salt['file.join'](zoomdata.backup['destination'], timestamp) %}
@@ -21,8 +23,6 @@ zoomdata_backup_latest:
     - force: True
     - onchanges:
       - file: zoomdata_backup_dir
-
-  {%- if zoomdata.backup['state'] or zoomdata.backup['services'] %}
 
 zoomdata_dump_readme:
   file.managed:
@@ -45,5 +45,4 @@ zoomdata_dump_readme:
     - onchanges:
       - file: zoomdata_backup_dir
 
-  {%- endif %}
 {%- endif %}

--- a/zoomdata/backup/retension.sls
+++ b/zoomdata/backup/retension.sls
@@ -8,7 +8,14 @@ zoomdata_backup_retension:
     - retain:
         most_recent: {{ zoomdata.backup['retention'] }}
     - strptime_format: {{ zoomdata.backup['strptime']|yaml() }}
+    {%- if not zoomdata['bootstrap'] and (
+           zoomdata.backup['state'] or zoomdata.backup['services']) %}
+    # Subscribe on changes only when any backup type is going to be made
     - onchanges:
       - file: zoomdata_backup_dir
+    {%- else %}
+    # FIXME: the state is really not stateful
+    - onlyif: test -d "{{ zoomdata.backup['destination'] }}"
+    {%- endif %}
 
 {%- endif %}

--- a/zoomdata/backup/state.sls
+++ b/zoomdata/backup/state.sls
@@ -17,6 +17,7 @@ zoomdata_dump_state:
     - group: root
     # Will contain passwords!
     - mode: 0600
+    # FIXME: subscribe on changes in repository settings
     - onchanges:
       - file: zoomdata_backup_dir
 

--- a/zoomdata/services/init.sls
+++ b/zoomdata/services/init.sls
@@ -4,6 +4,7 @@ include:
 {%- if not zoomdata['bootstrap'] %}
   - zoomdata.backup.layout
   - zoomdata.backup.state
+  # Stop services only when doing upgrade and services metadata backup
   - zoomdata.services.stop
   {%- if zoomdata['erase'] %}
   # Drop packages which do not being defined for installation.

--- a/zoomdata/services/install.sls
+++ b/zoomdata/services/install.sls
@@ -15,15 +15,6 @@
 include:
   - zoomdata.repo
 
-zoomdata_repository_update:
-  test.configurable_test_state:
-    - changes: {{ zoomdata['upgrade'] }}
-    - result: True
-    {%- if not zoomdata['bootstrap'] and zoomdata.backup['destination'] %}
-    - prereq_in:
-      - file: zoomdata_backup_dir
-    {%- endif %}
-
 {%- for package in packages %}
 
 {{ package }}_package:
@@ -39,8 +30,9 @@ zoomdata_repository_update:
     {%- if not zoomdata['bootstrap'] and not zoomdata['upgrade'] %}
     - prereq_in:
       - service: {{ package }}_stop_disable
-      {%- if zoomdata.backup['destination'] and
-             package in zoomdata.backup['services']|default([], true) %}
+      {%- if zoomdata.backup['destination'] and (
+             zoomdata.backup['state'] or
+             package in zoomdata.backup['services']|default([], true)) %}
       - file: zoomdata_backup_dir
       {%- endif %}
     {%- endif %}


### PR DESCRIPTION
* Do not restart all configured services on explicit request of backup
  if neither the Zoomdata state nor metadata has been defined in the
  Pillar.
* Do not backup the Zoomdata state if services backup is disabled
  and nothing to upgrade.