### PR TITLE
Run post installation commands on bootstrap only

### DIFF
--- a/zoomdata/services/install.sls
+++ b/zoomdata/services/install.sls
@@ -270,12 +270,9 @@ zoomdata-user-limits-conf:
   cmd.run:
     - name: {{ command }}
     - timeout: 300
-    - onchanges:
-      - pkg: {{ service }}
-    {%- if service in zoomdata['services'] %}
-    - watch_in:
-      - service: {{ service }}_start_enable
-    {%- endif %}
+    - require:
+      - pkg: {{ service }}_package
+    - onlyif: {{ zoomdata['bootstrap']|lower() }}
 
     {%- endfor %}
 


### PR DESCRIPTION
They probably wouldn't be idempotent and there is no common way to make them stateful.