### PR TITLE
Fix enabling of Systemd units for new services on upgrades

### DIFF
--- a/zoomdata/services/install.sls
+++ b/zoomdata/services/install.sls
@@ -38,7 +38,9 @@ include:
     - refresh: {{ loop.index == 1 }}
     {%- endif %}
     - skip_verify: {{ zoomdata.gpgkey|default(none, true) is none }}
-    {%- if not zoomdata['bootstrap'] and not zoomdata['upgrade'] %}
+    {%- if not zoomdata['bootstrap']
+       and not zoomdata['upgrade']
+       and package in zoomdata.local['services'] %}
     - prereq_in:
       - service: {{ package }}_stop_disable
       {%- if zoomdata.backup['destination'] and (

--- a/zoomdata/services/stop.sls
+++ b/zoomdata/services/stop.sls
@@ -1,20 +1,9 @@
 {%- from 'zoomdata/map.jinja' import init_available,
                                      zoomdata with context %}
 
-{%- set packages = zoomdata['packages'] +
-                   zoomdata.edc['packages'] +
-                   zoomdata.microservices['packages'] %}
-
-
 {%- if init_available %}
 
-  {%- set services = [] %}
-  {%- for service in packages + zoomdata.local['services'] %}
-    {%- if service and service not in services %}
-      {%- do services.append(service) %}
-    {%- endif %}
-  {%- endfor %}
-
+  {%- set services = zoomdata.local['services'] %}
   {%- if 'zoomdata-consul' in services %}
     {#- The ``zoomdata-consul`` is a special kind of service
         and should be stopped last. #}
@@ -32,6 +21,10 @@
   {%- endfor %}
 
 {%- else %}
+
+  {%- set packages = zoomdata['packages'] +
+                     zoomdata.edc['packages'] +
+                     zoomdata.microservices['packages'] %}
 
   {#- If there is no init system, just do nothing.
       The states here are rendered to satisfy upper level


### PR DESCRIPTION
It seems that Salt 2018.11 caches availability of the units.