### PR TITLE
Read PostgreSQL credentials from env vars

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -490,21 +490,26 @@ zoomdata:
 # Comment out the whole section to disable PostgreSQL installation and
 # configuration (depends on targeting set in the states ``top.sls`` file).
 # In that case, consider to configure the options above.
+
 postgres:
   # Create Zoomdata user and set password for the first time.
+  # The ``ZOOMDATA_POSTGRES_USER`` and ``ZOOMDATA_POSTGRES_PASS`` environment
+  # variables may override the defaults.
+  {%- set user = salt['environ.get']('ZOOMDATA_POSTGRES_USER', 'zoomdata') %}
+  {%- set pass = salt['environ.get']('ZOOMDATA_POSTGRES_PASS', 'PleaseChangeMe') %}
   users:
-    zoomdata:
+    {{ user }}:
       ensure: present
-      default_password: 'PleaseChangeMe'
+      default_password: {{ pass }}
 
   # Create databases for Zoomdata services
   databases:
     zoomdata:
-      owner: 'zoomdata'
+      owner: {{ user }}
     zoomdata-keyset:
-      owner: 'zoomdata'
+      owner: {{ user }}
     zoomdata-upload:
-      owner: 'zoomdata'
+      owner: {{ user }}
 
   # Backup extension for configuration files, defaults to ``.bak``.
   # Set ``False`` to stop creation of backups when config files change.

--- a/zoomdata/map.jinja
+++ b/zoomdata/map.jinja
@@ -194,9 +194,18 @@
     {% do zoomdata.config.update(salt['defaults.merge'](zoomdata.config, configs)) %}
 {% endif %}
 
+{# Read global PostgreSQL configuration for Salt #}
+{% set pg_host = salt['config.option']('postgres.host') %}
+{% set pg_port = salt['config.option']('postgres.port', 5432) %}
+{# These are administrative credentials #}
+{% set pg_user = salt['config.option']('postgres.user', 'postgres') %}
+{% set pg_pass =  salt['config.option']('postgres.pass') %}
+{% set pg_db = salt['config.option']('postgres.maintenance_db', 'postgres') %}
+
 {# Hard-code of some PostgreSQL authentication property names
    and expose administrative credentials for running raw ``psql`` command. #}
 {% set postgres = {
+    'connection_uri': '',
     'properties': (
         (
             'spring.datasource.url',
@@ -214,20 +223,42 @@
             'upload.destination.params.password'
         ),
     ),
-    'connection_uri': '',
-    'user': salt['config.option']('postgres.user', 'postgres'),
-    'password': salt['config.option']('postgres.pass'),
+    'user': pg_user,
+    'password': pg_pass,
 } %}
 
-{% set pg_host = salt['config.option']('postgres.host') %}
-{% set pg_port = salt['config.option']('postgres.port', 5432) %}
-{% set pg_db = salt['config.option']('postgres.maintenance_db', 'postgres') %}
+{# Read PostgreSQL connection details for the Zoomdata services
+   from the environment variables. #}
+{% set pg_host = salt['environ.get']('ZOOMDATA_POSTGRES_HOST', pg_host) %}
+{% set pg_port = salt['environ.get']('ZOOMDATA_POSTGRES_PORT', pg_port) %}
+{% set zd_user = salt['environ.get']('ZOOMDATA_POSTGRES_USER') %}
+{% set zd_pass = salt['environ.get']('ZOOMDATA_POSTGRES_PASS') %}
 
+{# This is used to manage databases during metadata restoration.
+   Automated restoration to remote PostgreSQL host is supported only when
+   the ``postgres.pass`` configuration option or Pillar value exists. #}
 {% if pg_host %}
     {% do postgres.update({
-        'connection_uri': 'postgresql://' ~ pg_host ~ ':' ~ pg_port ~ '/' ~ pg_db,
+        'connection_uri': 'postgresql://%s:%s/%s'|format(pg_host, pg_port, pg_db),
     }) %}
 {% endif %}
+
+{% for i in postgres.properties %}
+    {% if pg_host %}
+        {% set db = zoomdata.config.zoomdata.properties[i[0]].rsplit('/', 1)[1] %}
+        {% do zoomdata.config.zoomdata.properties.update({
+            i[0]: 'jdbc:postgresql://%s:%s/%s'|format(pg_host, pg_port, db),
+        }) %}
+    {% endif %}
+
+    {% if zd_user %}
+        {% do zoomdata.config.zoomdata.properties.update({i[1]: zd_user}) %}
+    {% endif %}
+
+    {% if zd_pass %}
+        {% do zoomdata.config.zoomdata.properties.update({i[2]: zd_pass}) %}
+    {% endif %}
+{% endfor %}
 
 {# Detect if we are using real init or building some image #}
 {% set init_available = grains['init'] != 'unknown' %}

--- a/zoomdata/restore/metadata.sls
+++ b/zoomdata/restore/metadata.sls
@@ -1,6 +1,9 @@
 {%- from 'zoomdata/map.jinja' import zoomdata, postgres with context %}
 
-{%- if zoomdata.restore['dir'] %}
+{%- if zoomdata.restore['dir']
+   and (not postgres['connection_uri']
+        or (postgres['connection_uri'] and postgres['password'])
+       ) %}
 
 include:
   - zoomdata.services.stop
@@ -49,6 +52,7 @@ zoomdata_restore_{{ salt['file.basename'](zoomdata.restore['dir']) }}_{{ dump }}
         {{ zoomdata.restore['bin'] }} {{ postgres.connection_uri }}
     - cwd: "{{ zoomdata.restore['dir'] }}"
     - runas: {{ zoomdata.restore['user'] }}
+      {#- The password is required for remote connections #}
       {%- if postgres.password %}
     - env:
       - PGUSER: {{ postgres.user|yaml() }}


### PR DESCRIPTION
The following properties could be used to provide connection details to external metadata storage:
- `ZOOMDATA_POSTGRES_HOST`
- `ZOOMDATA_POSTGRES_PORT`
- `ZOOMDATA_POSTGRES_USER`
- `ZOOMDATA_POSTGRES_PASS`

The user and all required databases should be already created.