### PR TITLE
Make Web server probe URI configurable

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -371,9 +371,14 @@ zoomdata:
   #services: 'all'
 
   # Perform additional post-installation setup
-  #setup:
+  setup:
+    # Zoomdata Web server URI path to probe for readiness. The path is relative
+    # to the context path configured in the ``server.servlet.context-path``
+    # property for the ``zoomdata`` service. It is expected that HTTP GET
+    # request on given URL will return HTTP status code 200.
+    probe: 'api/version'
   #  # How much time to wait in seconds until Zoomdata server would start to
-  #  # respond on API calls.
+  #  # respond on HTTP probe and API calls.
   #  timeout: 900
   #  # Configure users for accessing Zoomdata web interface. Setting passwords
   #  # for admin/supervisor is allowed only once after initial installation.

--- a/zoomdata/defaults.yaml
+++ b/zoomdata/defaults.yaml
@@ -142,13 +142,15 @@ zoomdata:
     - zoomdata
 
   setup:
+    # This is supported in both Zoomdata LTS 3.7 and latest 4.X
+    probe: 'actuator/info'
+    timeout: 900
     # Zoomdata API V2 URI path without context path
     api: api
     # Zoomdata API V2 default headers
     headers:
       Accept: '*/*'
       Content-Type: 'application/vnd.zoomdata.v2+json'
-    timeout: 900
     init:
       username: admin
       password: admin

--- a/zoomdata/setup.sls
+++ b/zoomdata/setup.sls
@@ -6,7 +6,8 @@
                   zoomdata.config.zoomdata.properties|default({}, true)
                 ) %}
 {#- We assume no TLS configuration and standard binding on 127.0.0.1, ::1 #}
-{%- set url = 'http://localhost:' ~ props['server.port'] ~  props['server.servlet.context-path'] %}
+{%- set url = 'http://localhost:%s%s'|format(props['server.port'],
+                                             props['server.servlet.context-path']) %}
 {%- set api = (url, zoomdata.setup['api'])|join('/') %}
 
 {%- set users = {} %}
@@ -34,7 +35,7 @@
 # Wait until Zoomdata server will be available
 zoomdata-wait:
   http.wait_for_successful_query:
-    - name: '{{ url }}/actuator/info'
+    - name: "{{ (url, zoomdata.setup['probe'])|join('/') }}"
     - wait_for: {{ zoomdata.setup['timeout'] }}
     - status: 200
     - failhard: True


### PR DESCRIPTION
IT-2027

This is required to provide backward compatible settings for legacy Zoomdata 2.6 deployments.